### PR TITLE
Gui caretaker major refactor

### DIFF
--- a/src/main/j/CLI.java
+++ b/src/main/j/CLI.java
@@ -236,7 +236,7 @@ public class CLI {
                             if(status != Controller.STATUS_CODES.SUCCESS){
                                 System.out.println("Relationship " + status.toString());
                             }else{
-                                System.out.println("Relationship between " + input[2] + " and " + input[3] + " created!");
+                                System.out.println("Relationship between " + input[2] + " and " + input[4] + " created!");
                             }
 
                             break;

--- a/src/main/j/CLI.java
+++ b/src/main/j/CLI.java
@@ -657,7 +657,7 @@ public class CLI {
                     break;*/
             }
             if(Main.gview){
-                GUI.displayGUI();
+                //GUI.displayGUI();
             }
         }
 

--- a/src/main/j/CLI.java
+++ b/src/main/j/CLI.java
@@ -457,7 +457,7 @@ public class CLI {
                     //The next part of the command is window
                     Main.gview = true;
                     GUI.startGUIMenu();
-                    Controller.updateGUI();
+                    Controller.updateGUI(Controller.FULL_REFRESH, null);
                     break;
 
                 case "undo":

--- a/src/main/j/Caretaker.java
+++ b/src/main/j/Caretaker.java
@@ -6,14 +6,12 @@ import java.util.ArrayList;
  * Keeps a list of the most recent changes, for undo/redo<br>
  * A more technical explanation is available in the source code
  */
-public class Caretaker {
-
-    private static Caretaker caretaker = null;
+public class Caretaker<T> {
 
     /**
      * a tweaked full ascending stack that preserves the elements that are "popped" off
      */
-    private final ArrayList<ModelDiagram.Memento> stack;
+    private final ArrayList<j.Memento<T>> stack;
 
     /*
         This explanation will not go into edge cases, just how it works
@@ -69,21 +67,10 @@ public class Caretaker {
     /**
      * This class is a singleton so the c'tor is private
      */
-    private Caretaker() {
+    public Caretaker() {
         this.stackPointer = -1;
         this.stackSize = 0;
         this.stack = new ArrayList<>();
-    }
-
-    /**
-     * Gets the instance of the sole Caretaker object
-     * @return the Caretaker object
-     */
-    public static Caretaker getInstance() {
-        if (caretaker == null) {
-            caretaker = new Caretaker();
-        }
-        return caretaker;
     }
 
     /*
@@ -98,7 +85,7 @@ public class Caretaker {
      * returns a Memento Object containing the state of the program just before the most recent change
      * @return Memento Object with the most recent changes, or null if the undo is invalid
      */
-    public ModelDiagram.Memento undo() {
+    public Memento<T> undo() {
         if (this.stackSize == 0 || this.stackPointer == 0)
             return null;
 
@@ -127,7 +114,7 @@ public class Caretaker {
      * returns a Memento Object containing the state of the program before the most recent undo
      * @return Memento object containing the state of the program before the most recent undo, or null if the redo is invalid
      */
-    public ModelDiagram.Memento redo() {
+    public Memento<T> redo() {
         //CASE: Stack is empty or stackPointer is already at 0 (the state of the program is already the oldest recorded state)
         if (this.stackSize == 0 || this.stackPointer == (stackSize - 1))
             return null;
@@ -152,7 +139,7 @@ public class Caretaker {
      * Adds a Memento object to the stack and updates the stack pointer and stack size accordingly
      * @param snapshot Memento Object to add to the stack
      */
-    public void updateChange(final ModelDiagram.Memento snapshot) {
+    public void updateChange(final Memento<T> snapshot) {
         if (snapshot == null)
             throw new IllegalArgumentException("null snapshot passed to Caretaker.updateChange");
 

--- a/src/main/j/Caretaker.java
+++ b/src/main/j/Caretaker.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
  * Keeps a list of the most recent changes, for undo/redo<br>
  * A more technical explanation is available in the source code
  */
-public class Caretaker<T> {
+public class Caretaker<T extends gCloneable<T>> {
 
     /**
      * a tweaked full ascending stack that preserves the elements that are "popped" off

--- a/src/main/j/Caretaker.java
+++ b/src/main/j/Caretaker.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
  * Keeps a list of the most recent changes, for undo/redo<br>
  * A more technical explanation is available in the source code
  */
-public class Caretaker<T extends gCloneable<T>> {
+public class Caretaker<T extends GCloneable<T>> {
 
     /**
      * a tweaked full ascending stack that preserves the elements that are "popped" off

--- a/src/main/j/Caretaker.java
+++ b/src/main/j/Caretaker.java
@@ -139,7 +139,7 @@ public class Caretaker<T extends gCloneable<T>> {
      * Adds a Memento object to the stack and updates the stack pointer and stack size accordingly
      * @param snapshot Memento Object to add to the stack
      */
-    public void updateChange(final Memento<T> snapshot) {
+    public void addChange(final Memento<T> snapshot) {
         if (snapshot == null)
             throw new IllegalArgumentException("null snapshot passed to Caretaker.updateChange");
 
@@ -150,6 +150,19 @@ public class Caretaker<T extends gCloneable<T>> {
             this.stack.set(stackPointer, snapshot);
         }
         this.stackSize = this.stackPointer + 1;
+    }
+
+
+    /**
+     * Replaces the Memento object on the top of the stack<br>
+     * This is mainly for GUI when boxes are moved, the moves should be preserved but they should not be added to the stack
+     * @param snapshot Memento Object that will take place of the object on the top of the stack
+     */
+    public void updateChange(final Memento<T> snapshot){
+        if (snapshot == null)
+            throw new IllegalArgumentException("null snapshot passed to Caretaker.updateChange");
+
+        this.stack.set(stackPointer, snapshot);
 
     }
 

--- a/src/main/j/ClassBox.java
+++ b/src/main/j/ClassBox.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 
-public class ClassBox implements Cloneable {
+public class ClassBox implements gCloneable<ClassBox>, Cloneable {
 
     public boolean equals(final ClassBox cb) {
         return this.equals(cb.getName());
@@ -39,11 +39,7 @@ public class ClassBox implements Cloneable {
 
     @Override
     public ClassBox clone() {
-        try {
-            return new ClassBox((ClassBox) super.clone());
-        } catch (Exception e) {
-            return null;
-        }
+        return new ClassBox(this);
     }
 
     private ClassBox(final ClassBox cb) {

--- a/src/main/j/ClassBox.java
+++ b/src/main/j/ClassBox.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 
-public class ClassBox implements gCloneable<ClassBox>, Cloneable {
+public class ClassBox implements GCloneable<ClassBox>, Cloneable {
 
     public boolean equals(final ClassBox cb) {
         return this.equals(cb.getName());

--- a/src/main/j/ClassBox.java
+++ b/src/main/j/ClassBox.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 
-public class ClassBox implements GCloneable<ClassBox>, Cloneable {
+public class ClassBox implements GCloneable<ClassBox> {
 
     public boolean equals(final ClassBox cb) {
         return this.equals(cb.getName());

--- a/src/main/j/Controller.java
+++ b/src/main/j/Controller.java
@@ -14,13 +14,13 @@ public class Controller implements j.Observable {
         observers.add(observer);
     }
 
-    public void notifyObservers() {
+    public void notifyObservers(final int reason, final String msg) {
         for (Observer o : Controller.observers)
-            o.update();
+            o.update(reason, msg);
     }
 
-    public static void updateGUI() {
-        ControllerObservable.notifyObservers();
+    public static void updateGUI(final int reason, final String msg) {
+        ControllerObservable.notifyObservers(reason, msg);
     }
 
     public enum STATUS_CODES {
@@ -46,6 +46,16 @@ public class Controller implements j.Observable {
             return this.msg;
         }
     }
+
+    public final static int ADD_CLASS = 0,
+            RENAME_CLASS = 1,
+            ADD_RELATIONSHIP = 2,
+            DELETE_RELATIONSHIP = 3,
+            DELETE_CLASS = 4,
+            UPDATE_ATTRIBUTE = 5,
+            UNDO = 6,
+            REDO = 7,
+            FULL_REFRESH = 8;
 
     private Controller() {
     }

--- a/src/main/j/GCloneable.java
+++ b/src/main/j/GCloneable.java
@@ -1,0 +1,5 @@
+package j;
+
+public interface GCloneable<T> {
+    T clone();
+}

--- a/src/main/j/GUI.java
+++ b/src/main/j/GUI.java
@@ -200,8 +200,10 @@ public class GUI extends JFrame implements j.Observer {
     }
 
     public static void restoreSnapshot(final Memento<ClassPanel> p) {
-        classes = Memento.restoreSnapshot(p);
-        redrawGUI();
+        if(p != null) {
+            classes = Memento.restoreSnapshot(p);
+            redrawGUI();
+        }
     }
 
     private static ClassPanel findClassPanel(final String name) {

--- a/src/main/j/GUI.java
+++ b/src/main/j/GUI.java
@@ -129,6 +129,7 @@ public class GUI extends JFrame implements j.Observer {
                     //We only need to update the coordinates when the user is done moving the boxes
                     thisPanel.xDelta = thisPanel.getLocation().x;
                     thisPanel.yDelta = thisPanel.getLocation().y;
+                    caretaker.updateChange(Memento.createSnapshot(classes));
                     //updateChange();   //uncomment this if you want the undo/redo to undo the last box move
                 }
             });
@@ -196,7 +197,7 @@ public class GUI extends JFrame implements j.Observer {
     }
 
     public static void updateChange() {
-        caretaker.updateChange(Memento.createSnapshot(classes));
+        caretaker.addChange(Memento.createSnapshot(classes));
     }
 
     public static void restoreSnapshot(final Memento<ClassPanel> p) {
@@ -309,8 +310,10 @@ public class GUI extends JFrame implements j.Observer {
                 updateChange();
                 break;
             case Controller.ADD_RELATIONSHIP:
+                updateChange();
                 break;
             case Controller.DELETE_RELATIONSHIP:
+                updateChange();
                 break;
             case Controller.DELETE_CLASS:
                 GUIDeleteClass(msg);

--- a/src/main/j/GUI.java
+++ b/src/main/j/GUI.java
@@ -4,11 +4,8 @@ package j;
 // Menu bar to add menu items
 
 import javax.swing.*;
-import javax.swing.border.LineBorder;
 import java.awt.*;
 import java.awt.event.*;
-import java.awt.geom.Line2D;
-import java.awt.geom.Point2D;
 import java.util.ArrayList;
 import java.util.LinkedList;
 
@@ -53,7 +50,7 @@ public class GUI extends JFrame implements j.Observer {
 
     }
 
-    public static class ClassPanel extends JPanel implements gCloneable<ClassPanel>, Cloneable {
+    public static class ClassPanel extends JPanel implements GCloneable<ClassPanel>, Cloneable {
         private final String name;
 
         private final String type;

--- a/src/main/j/GUI.java
+++ b/src/main/j/GUI.java
@@ -43,6 +43,9 @@ public class GUI extends JFrame implements j.Observer {
 
         private int width;
 
+        //to help make dragging smooth
+        public MouseEvent pressed;
+
         public ClassPanel(final String[][] details, final int x, final int y) {
             super(new GridLayout(0, 1));
             this.name = details[Controller.DETAILS_NAME_TYPE][0];
@@ -102,6 +105,23 @@ public class GUI extends JFrame implements j.Observer {
                 this.height += this.heightScale;
             this.setBounds(this.xDelta, this.yDelta, this.width, this.height);
             this.setBorder(BorderFactory.createLineBorder(Color.black));
+
+            //Add the mouse event handlers
+            ClassPanel thisPanel = this;
+            this.addMouseListener(new MouseAdapter() {
+                @Override
+                public void mousePressed(MouseEvent me){
+                    thisPanel.pressed = me;
+                }
+            });
+
+            this.addMouseMotionListener(new MouseMotionAdapter() {
+                @Override
+                public void mouseDragged(MouseEvent me) {
+                    me.translatePoint(thisPanel.getLocation().x - thisPanel.pressed.getX(), thisPanel.getLocation().y- thisPanel.pressed.getY());
+                    thisPanel.setLocation(me.getX(),me.getY());
+                }
+            });
         }
 
         public ClassPanel(final String[][] details) {
@@ -512,6 +532,21 @@ public class GUI extends JFrame implements j.Observer {
         }
 
     }
+
+    public void handleDrag(final JPanel panel){
+        final JPanel p = panel;
+        panel.addMouseMotionListener(new MouseMotionAdapter() {
+
+           @Override
+           public void mouseDragged(MouseEvent me){
+               me.translatePoint(me.getComponent().getLocation().x, me.getComponent().getLocation().y);
+               p.setLocation(me.getX(), me.getY());
+            }
+
+        });
+
+    }
+
 
     public static void drawClassPanel(final ClassPanel c) {
         guiWindow.getContentPane().add(c);

--- a/src/main/j/GUI.java
+++ b/src/main/j/GUI.java
@@ -202,10 +202,10 @@ public class GUI extends JFrame implements j.Observer {
     static JMenuBar mainMenu;
 
     // Creates individual dropdown menus for each category within the overall menu
-    static JMenu parameterDropdown, displayDropdown, classDropdown, attributeDropdown, relationshipDropdown, saveLoadDropdown, helpDropdown, CLIDropdown;
+    static JMenu parameterDropdown, displayDropdown, classDropdown, attributeDropdown, relationshipDropdown, saveLoadDropdown, helpDropdown, CLIDropdown, undoRedoDropdown;
 
     // Individual menu items/buttons under their individual category menus
-    static JMenuItem display, addClass, deleteClass, renameClass, addAtt, delAtt, renameAtt, addRelation, delRelation, save, load, help, addPar, delPar, renPar, openCLI;
+    static JMenuItem display, addClass, deleteClass, renameClass, addAtt, delAtt, renameAtt, addRelation, delRelation, save, load, help, addPar, delPar, renPar, openCLI, menuUndo, menuRedo;
 
 
     //creates a frame to be the main, base window to hold the entirety of the GUI
@@ -348,6 +348,16 @@ public class GUI extends JFrame implements j.Observer {
 
     }
 
+    //made these one liners to make it simpler to call undo/redo
+    public static void GUIUndo(){
+        restoreSnapshot(caretaker.undo());
+    }
+
+    public static void GUIRedo(){
+        restoreSnapshot(caretaker.redo());
+    }
+
+
     public void update(int reason, String msg) {
         switch (reason) {
             case Controller.ADD_CLASS:
@@ -375,10 +385,10 @@ public class GUI extends JFrame implements j.Observer {
                 updateChange();
                 break;
             case Controller.UNDO:
-                restoreSnapshot(caretaker.undo());
+                GUIUndo();
                 break;
             case Controller.REDO:
-                restoreSnapshot(caretaker.redo());
+                GUIRedo();
                 break;
             case Controller.FULL_REFRESH:
                 GUIFullRefresh();
@@ -395,6 +405,17 @@ public class GUI extends JFrame implements j.Observer {
 
         guiWindow = new JFrame("UML Editor");
         guiWindow.getContentPane().setBackground(Color.BLUE);
+        guiWindow.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                if(e.getKeyChar() == 'u'){
+                    GUIUndo();
+                }
+                else if (e.getKeyChar() == 'r'){
+                    GUIRedo();
+                }
+            }
+        });
         // create a menubar
         mainMenu = new JMenuBar();
 
@@ -406,7 +427,6 @@ public class GUI extends JFrame implements j.Observer {
             }
         });
         displayDropdown.add(display);
-
 
         //Adds a class and updates the display to show the new class in a box
         classDropdown = new JMenu("Class");
@@ -758,6 +778,23 @@ public class GUI extends JFrame implements j.Observer {
         });
         CLIDropdown.add(openCLI);
 
+        //Undo/Redo menu options
+        undoRedoDropdown = new JMenu("Undo/Redo");
+        menuUndo = new JMenuItem(new AbstractAction("Undo") {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                GUIUndo();
+            }
+        });
+        menuRedo = new JMenuItem(new AbstractAction("Redo") {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                GUIRedo();
+            }
+        });
+        undoRedoDropdown.add(menuUndo);
+        undoRedoDropdown.add(menuRedo);
+
         // add individual dropdown menus to menu bar
         mainMenu.add(displayDropdown);
         mainMenu.add(classDropdown);
@@ -765,7 +802,9 @@ public class GUI extends JFrame implements j.Observer {
         mainMenu.add(parameterDropdown);
         mainMenu.add(relationshipDropdown);
         mainMenu.add(saveLoadDropdown);
+        mainMenu.add(undoRedoDropdown);
         mainMenu.add(helpDropdown);
+
 
         // add menubar to our main GUI display frame
         guiWindow.setJMenuBar(mainMenu);

--- a/src/main/j/GUI.java
+++ b/src/main/j/GUI.java
@@ -27,8 +27,8 @@ public class GUI extends JFrame implements j.Observer {
     private static ArrayList<ClassPanel> classes;
     private final static Caretaker<ClassPanel> caretaker = new Caretaker<>();
 
-    static{
-        classes  = new ArrayList<>();
+    static {
+        classes = new ArrayList<>();
         updateChange();
     }
 
@@ -147,7 +147,7 @@ public class GUI extends JFrame implements j.Observer {
             this(details, 0, 0);
         }
 
-        private ClassPanel(final ClassPanel panel){
+        private ClassPanel(final ClassPanel panel) {
             this.name = panel.name;
             this.type = panel.type;
             this.yDelta = panel.yDelta;
@@ -174,7 +174,7 @@ public class GUI extends JFrame implements j.Observer {
         @Override
         public ClassPanel clone() {
             try {
-                return (new ClassPanel((ClassPanel)super.clone()));
+                return (new ClassPanel((ClassPanel) super.clone()));
             } catch (Exception ignored) {
                 return null;
             }
@@ -194,16 +194,17 @@ public class GUI extends JFrame implements j.Observer {
     //creates a frame to be the main, base window to hold the entirety of the GUI
     static JFrame guiWindow;
     private static GUI guiObserver;
-    public static GUI getInstance(){
-        if(guiObserver == null)
+
+    public static GUI getInstance() {
+        if (guiObserver == null)
             return new GUI();
 
         return guiObserver;
     }
 
-    private ClassPanel findClassPanel(final String name){
-        for(ClassPanel p : GUI.classes){
-            if(p.name.equals(name))
+    private ClassPanel findClassPanel(final String name) {
+        for (ClassPanel p : GUI.classes) {
+            if (p.name.equals(name))
                 return p;
         }
         return null;
@@ -220,14 +221,14 @@ public class GUI extends JFrame implements j.Observer {
     private void GUIRenameClass(final String name) {
         //The names are passed in the format [old name]\n[new name]
         String[] names = name.split("\n");
-        if(names.length != 2)
+        if (names.length != 2)
             return;
 
         String oldName = names[0];
         String newName = names[1];
         System.out.println(oldName + "\n" + newName);
         ClassPanel oldPanel = findClassPanel(oldName);
-        if(oldPanel == null)
+        if (oldPanel == null)
             return;
 
         String[][] details = Controller.listAllClassDetails(newName);
@@ -248,9 +249,9 @@ public class GUI extends JFrame implements j.Observer {
         guiWindow.getContentPane().repaint();
     }
 
-    private void GUIUpdateAttribute(final String name){
+    private void GUIUpdateAttribute(final String name) {
         ClassPanel oldPanel = findClassPanel(name);
-        if(oldPanel == null)
+        if (oldPanel == null)
             return;
 
         String[][] details = Controller.listAllClassDetails(name);
@@ -263,7 +264,7 @@ public class GUI extends JFrame implements j.Observer {
         guiWindow.getContentPane().repaint();
     }
 
-    private void GUIFullRefresh(){
+    private void GUIFullRefresh() {
         guiWindow.getContentPane().removeAll();
         String[][][] classes = Controller.listEveryClassAndAllDetails();
         GUI.classes.clear();
@@ -272,14 +273,14 @@ public class GUI extends JFrame implements j.Observer {
 
         for (String[][] c : classes) {
             GUI.classes.add(new ClassPanel(c, x, 0));
-            x += 200;
+            x += 100;
         }
 
         for (ClassPanel c : GUI.classes)
             drawClassPanel(c);
     }
 
-    public static void redrawGUI(){
+    public static void redrawGUI() {
         guiWindow.getContentPane().removeAll();
         for (ClassPanel c : GUI.classes)
             drawClassPanel(c);
@@ -325,23 +326,23 @@ public class GUI extends JFrame implements j.Observer {
 
     }
 
-    public static void updateChange(){
+    public static void updateChange() {
         ArrayList<ClassPanel> snapList = createSnapshot(classes);
         j.Memento<ClassPanel> snapshot = new Memento<>(snapList);
         caretaker.updateChange(snapshot);
     }
 
-    public static ArrayList<ClassPanel> createSnapshot(final ArrayList<ClassPanel> snapshot){
+    public static ArrayList<ClassPanel> createSnapshot(final ArrayList<ClassPanel> snapshot) {
         ArrayList<ClassPanel> snap = new ArrayList<>();
-        for(ClassPanel p : snapshot){
+        for (ClassPanel p : snapshot) {
             snap.add(p.clone());
         }
         return snap;
     }
 
-    public static void restoreSnapshot(final ArrayList<ClassPanel> snapshot){
+    public static void restoreSnapshot(final ArrayList<ClassPanel> snapshot) {
         ArrayList<ClassPanel> list = new ArrayList<>();
-        for(ClassPanel p : snapshot){
+        for (ClassPanel p : snapshot) {
             list.add(p.clone());
         }
         classes = list;
@@ -756,290 +757,8 @@ public class GUI extends JFrame implements j.Observer {
         for (ClassPanel c : GUI.classes)
             drawClassPanel(c);
 
-
-        //guiWindow.invalidate();
-        //guiWindow.repaint();
-
-        //guiWindow.setLayout(null);
-
-        //ShapeDrawing test;
-
-        //Issue: graphicy2 doesn't pass in correctly as it says g2, which is what graphicy below gets, is null.
-        /*for(int i = 0; i < classNames.length; i++){
-            //ShapeDrawing classBoxy = new ShapeDrawing();
-            ShapeDrawing test = new ShapeDrawing();
-            test.setBorder(new LineBorder(Color.BLUE, 3));
-            //Graphics2D graphicy2 = classBoxy.getGraphicy();
-            //classBoxy.drawClass(classNames[i], 0, 0, graphicy2);
-            guiWindow.add(test);
-        } */
-
-        //int numberOfClasses = Controller.getCreatedClassesSize();
-        //String[] classNames = Controller.listClasses();
-        //for(int i = 0; i < numberOfClasses; i++){
-        //MyDraggableComponent newbie = new MyDraggableComponent();
-        //guiWindow.add(newbie);
-        // }
-
     }
 
-    /* public static class ShapeDrawing extends JComponent{
-        //Start of blobs
-        private volatile int screenX = 0;
-        private volatile int screenY = 0;
-        private volatile int myX = 0;
-        private volatile int myY = 0;
-        //End of blobs
-
-        public ShapeDrawing(){
-            super();
-        // code blob error report: Same as below unfortunately :<
-        //Start of blob
-            addMouseListener(new MouseListener() {
-
-                @Override
-                public void mouseClicked(MouseEvent e) { }
-
-                @Override
-                public void mousePressed(MouseEvent e) {
-                    screenX = e.getXOnScreen();
-                    screenY = e.getYOnScreen();
-
-                    myX = getX();
-                    myY = getY();
-                }
-
-                @Override
-                public void mouseReleased(MouseEvent e) { }
-
-                @Override
-                public void mouseEntered(MouseEvent e) { }
-
-                @Override
-                public void mouseExited(MouseEvent e) { }
-
-            });
-            addMouseMotionListener(new MouseMotionListener() {
-
-                @Override
-                public void mouseDragged(MouseEvent e) {
-                    int deltaX = e.getXOnScreen() - screenX;
-                    int deltaY = e.getYOnScreen() - screenY;
-
-                    setLocation(myX + deltaX, myY + deltaY);
-                }
-
-                @Override
-                public void mouseMoved(MouseEvent e) { }
-
-            });
-        //end of blob
-
-        }
-        public void paint(Graphics g){
-            Graphics2D g2 = (Graphics2D) g;
-            //Spacing out based on the number of classes
-            int numberOfClasses = Controller.getCreatedClassesSize();
-            // number of total spaces including class boxes and empty spaces in between
-            // If there are 3 classes, it has 3 spots with one classbox space between each box
-            int totalSpace = (2 * numberOfClasses) + 1;
-            //Overall width of panel divided by spots
-            int spaceWidth = 1000/totalSpace;
-            //Current x coordinate
-            int curx = spaceWidth;
-            //Stores coordinates of each class when printed for relationship printing
-            LinkedList<Integer> coords = new LinkedList<>();
-            //Goes through all classes and prints them
-            String[] classNames = Controller.listClasses();
-            //this will stick every other class on an upper row, and the ones in between on a lower row
-
-            /*TODO remove the for loop. Place it in it's own method to print all classes. This print all classes method will be
-              outside of the shape drawing class, and will call shapedrawing for each class listed. You'll need int numberofclasses
-              from above to be able to do this. This could get complicated as it might require moving multiple methods
-               outside of ShapeDrawing*/
-            /*for(int i = 0; i < numberOfClasses; i++){
-                //issue report with the mouse listeners in the if/else below:
-                // Classes are duplicated in display, so for 1 class, 2 show up. They're in weirdly bounded boxes,
-                // and the components in each box are not moveable
-                if(i % 2 == 0){
-                    drawClass(classNames[i], curx, 200, g2);
-
-                    coords.add(curx);
-                    coords.add(200);
-                }
-                else{
-                    drawClass(classNames[i], curx, 400, g2);
-                    coords.add(curx);
-                    coords.add(400);
-                }
-                curx += (1.5 * spaceWidth);
-            }
-            String[] classes = Controller.listClasses();
-            //Prints the line for each relationship
-            int rcount = 0;
-            for (int i = 0; i < Controller.getCreatedClassesSize(); i++){
-                String[][] relationships = Controller.listRelationships();
-                for(int j = 0; j<relationships[i].length; j++) {
-                    //For each relationship, retrieve the coordinates of each, and draw a line between them
-                    int class1XIndex = i * 2; //index of where the coordinates are in the array
-                    int class1YIndex = class1XIndex + 1;
-                    String[] relationship = relationships[i][j].split(" ");
-                    int class2Index = -1;
-                    for (int k = 0; k < classes.length; k++) {
-                        if (relationship[2].equals(classes[k])) {
-                            class2Index = k;
-                        }
-                    }
-                    int class2XIndex = class2Index * 2;
-
-                    int class2YIndex = class2XIndex + 1;
-                    int class1XCoords = coords.get(class1XIndex) + (rcount * 20);
-                    int class1YCoords = coords.get(class1YIndex) - (rcount * 10);
-                    int class2XCoords = coords.get(class2XIndex) + (rcount * 20);
-                    int class2YCoords = coords.get(class2YIndex) - (rcount * 10);
-                    class1XCoords += 10;
-                    //scooches the line over to the right a bit so it isn't on the corner
-                    class2XCoords += 10;
-                    String relationshipType = relationship[1];
-                    if (relationshipType.equals("aggregates") || relationshipType.equals("composes")) {
-                        if (class1YCoords == class2YCoords) {
-                            g2.drawLine(class1XCoords, class1YCoords + (rcount * 10), class1XCoords, class1YCoords - 20);
-                            g2.drawLine(class1XCoords, class1YCoords - 20, class2XCoords, class2YCoords - 20);
-                            g2.drawLine(class2XCoords, class2YCoords + (rcount * 10), class2XCoords, class2YCoords - 20);
-                        }
-                        else {
-                            if (class1XCoords < class2XCoords) {
-                                g2.drawLine(class1XCoords, class1YCoords + (rcount * 10), class1XCoords, class1YCoords - 20);
-                                g2.drawLine(class1XCoords, class1YCoords - 20, class1XCoords + getClassWidth(relationship[0], g2) + 40, class1YCoords - 20);
-                                g2.drawLine(class1XCoords + getClassWidth(relationship[0], g2) + 40, class1YCoords - 20, class1XCoords + getClassWidth(relationship[0], g2) + 40, class2YCoords - 20);
-                                g2.drawLine(class1XCoords + getClassWidth(relationship[0], g2) + 40, class2YCoords - 20, class2XCoords, class2YCoords - 20);
-                                g2.drawLine(class2XCoords, class2YCoords + (rcount * 10), class2XCoords, class2YCoords - 20);
-                            } else {
-                                g2.drawLine(class1XCoords, class1YCoords + (rcount * 10), class1XCoords, class1YCoords - 20);
-                                g2.drawLine(class1XCoords, class1YCoords - 20, class1XCoords - (class1XCoords - class2XCoords - getClassWidth(relationship[2], g2) - 20), class1YCoords - 20);
-                                g2.drawLine(class1XCoords - (class1XCoords - class2XCoords - getClassWidth(relationship[2], g2) - 20), class1YCoords - 20, class1XCoords - (class1XCoords - class2XCoords - getClassWidth(relationship[2], g2) - 20), class2YCoords - 20);
-                                g2.drawLine(class1XCoords - (class1XCoords - class2XCoords - getClassWidth(relationship[2], g2) - 20), class2YCoords - 20, class2XCoords, class2YCoords - 20);
-                                g2.drawLine(class2XCoords, class2YCoords + (rcount * 10), class2XCoords, class2YCoords - 20);
-                            }
-                        }
-                        class2YCoords += 10*rcount-20;
-                        int[] xpoints = {class2XCoords, class2XCoords - 10, class2XCoords, class2XCoords + 10};
-                        int[] ypoints = {class2YCoords, class2YCoords + 10, class2YCoords + 20, class2YCoords + 10};
-                        int npoints = 4;
-                        if (relationshipType.equals("aggregates")) {
-                            g2.drawPolygon(xpoints, ypoints, npoints);
-                        } else {
-                            g2.fillPolygon(xpoints, ypoints, npoints);
-                        }
-                    }
-                    else{
-                        if (class1YCoords == class2YCoords) {
-                            drawDashedLine(g2, class1XCoords, class1YCoords + (rcount * 10), class1XCoords, class1YCoords - 20);
-                            drawDashedLine(g2, class1XCoords, class1YCoords - 20, class2XCoords, class2YCoords - 20);
-                            drawDashedLine(g2, class2XCoords, class2YCoords + (rcount * 10), class2XCoords, class2YCoords - 20);
-                        }
-                        else {
-                            if (class1XCoords < class2XCoords) {
-                                drawDashedLine(g2, class1XCoords, class1YCoords + (rcount * 10), class1XCoords, class1YCoords - 20);
-                                drawDashedLine(g2, class1XCoords, class1YCoords - 20, class1XCoords + getClassWidth(relationship[0], g2) + 40, class1YCoords - 20);
-                                drawDashedLine(g2, class1XCoords + getClassWidth(relationship[0], g2) + 40, class1YCoords - 20, class1XCoords + getClassWidth(relationship[0], g2) + 40, class2YCoords - 20);
-                                drawDashedLine(g2, class1XCoords + getClassWidth(relationship[0], g2) + 40, class2YCoords - 20, class2XCoords, class2YCoords - 20);
-                                drawDashedLine(g2, class2XCoords, class2YCoords + (rcount * 10), class2XCoords, class2YCoords - 20);
-                            } else {
-                                drawDashedLine(g2, class1XCoords, class1YCoords + (rcount * 10), class1XCoords, class1YCoords - 20);
-                                drawDashedLine(g2, class1XCoords, class1YCoords - 20, class1XCoords - (class1XCoords - class2XCoords - getClassWidth(relationship[2], g2) - 20), class1YCoords - 20);
-                                drawDashedLine(g2, class1XCoords - (class1XCoords - class2XCoords - getClassWidth(relationship[2], g2) - 20), class1YCoords - 20, class1XCoords - (class1XCoords - class2XCoords - getClassWidth(relationship[2], g2) - 20), class2YCoords - 20);
-                                drawDashedLine(g2, class1XCoords - (class1XCoords - class2XCoords - getClassWidth(relationship[2], g2) - 20), class2YCoords - 20, class2XCoords, class2YCoords - 20);
-                                drawDashedLine(g2, class2XCoords, class2YCoords + (rcount * 10), class2XCoords, class2YCoords - 20);
-                            }
-                        }
-                        class2YCoords += 10*rcount-20;
-                        int[] xpoints = {class2XCoords,class2XCoords-10,class2XCoords+10};
-                        int[] ypoints = {class2YCoords+20,class2YCoords,class2YCoords};
-                        int npoints = 3;
-                        g2.drawPolygon(xpoints, ypoints, npoints);
-                    }
-                    rcount++;
-                }
-            }
-        }
-        public int getClassWidth(String className, Graphics2D g2){
-            String[][] classDetails = Controller.listAllClassDetails(className);
-            int width = g2.getFontMetrics().stringWidth(className);
-            //Set width to largest of the attribute toStrings
-            for(int i = 0; i < classDetails[Controller.DETAILS_METHODS].length; i++){
-                if(g2.getFontMetrics().stringWidth(classDetails[Controller.DETAILS_METHODS][i]) > width){
-                    width = g2.getFontMetrics().stringWidth(classDetails[Controller.DETAILS_METHODS][i]) + 10;
-                }
-            }
-            for(int i = 0; i < classDetails[Controller.DETAILS_FIELDS].length; i++){
-                if(g2.getFontMetrics().stringWidth(classDetails[Controller.DETAILS_FIELDS][i]) > width){
-                    width = g2.getFontMetrics().stringWidth(classDetails[Controller.DETAILS_FIELDS][i]) + 10;
-                }
-            }
-
-            String classType = "<<"+classDetails[Controller.DETAILS_NAME_TYPE][1].toLowerCase()+">>";
-            if(width<g2.getFontMetrics().stringWidth(classType)){
-                width = g2.getFontMetrics().stringWidth(classType);
-            }
-            //Add 10 to width for nice spacing
-            width += 10;
-            return width;
-        }
-        //Draws the class boxes
-        public void drawClass(String className, int x, int y, Graphics2D g2){
-            //TODO issue report with the mouse listeners in the if/else below:
-            // Classes are duplicated in display, so for 1 class, 2 show up. They're in weirdly bounded boxes,
-            // and the components in each box are not moveable
-
-            //number of fields and methods
-            String[][] classDetails = Controller.listAllClassDetails(className);
-            int height = 15 * (classDetails[Controller.DETAILS_METHODS].length + classDetails[Controller.DETAILS_FIELDS].length+2);
-            int width = getClassWidth(className, g2);
-            //If the box is not a class, it needs a special header above the name
-            boolean isClass = classDetails[Controller.DETAILS_NAME_TYPE][1].equals("CLASS");
-            if(!isClass)
-                height += 15;
-            //Outer rectangle
-            g2.drawRect(x,y,width,height);
-            //If the box is not a class, it needs a special header above the name
-            String classType = "<<"+classDetails[Controller.DETAILS_NAME_TYPE][1].toLowerCase()+">>";
-            if(!isClass) {
-                g2.drawString(classType, x + width / 2 - g2.getFontMetrics().stringWidth(classType)/2, y + 15);
-                y += 15;
-            }
-            //Write Class name
-            g2.drawString(className, x + ((width/2) - (g2.getFontMetrics().stringWidth(className)/2)), y+15);
-            //Draw line under the name
-            g2.drawLine(x,y + 17,x+width, y+17);
-            //moves down twice the spacing of above
-            y = y + 30;
-            //For each attribute, print the gui toString
-            for(int i=0; i <classDetails[Controller.DETAILS_FIELDS].length; i++){
-                g2.drawString(classDetails[Controller.DETAILS_FIELDS][i], x+10, y);
-                y += 15;
-            }
-            g2.drawLine(x,y - 12,x+width, y - 12);
-            for(int i=0; i < classDetails[Controller.DETAILS_METHODS].length; i++){
-                g2.drawString(classDetails[Controller.DETAILS_METHODS][i], x+10, y);
-                //moves down 15
-                y += 15;
-            }
-            //TODO added below line displayGui
-
-
-        }
-        public static void drawDashedLine(Graphics2D g, int x1, int y1, int x2, int y2){
-            Graphics2D g2d = (Graphics2D) g.create();
-            Stroke dashed = new BasicStroke(3, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 0, new float[]{9}, 0);
-            g2d.setStroke(dashed);
-            g2d.drawLine(x1, y1, x2, y2);
-            g2d.dispose();
-        }
-    } */
-
-
-    //Start of absolute mess of code
 
     public static class MyDraggableComponent
             extends JComponent {
@@ -1390,10 +1109,4 @@ public class GUI extends JFrame implements j.Observer {
         }
     }
 
-
 }
-
-// make the buttons work
-// to display, change the actual display button under Display to open CLI
-// we need to get the actual class boxes listed
-// all of a class's fields, methods, and relationships are added to the box as well

--- a/src/main/j/GUI.java
+++ b/src/main/j/GUI.java
@@ -7,6 +7,8 @@ import javax.swing.*;
 import javax.swing.border.LineBorder;
 import java.awt.*;
 import java.awt.event.*;
+import java.awt.geom.Line2D;
+import java.awt.geom.Point2D;
 import java.util.ArrayList;
 import java.util.LinkedList;
 
@@ -32,6 +34,25 @@ public class GUI extends JFrame implements j.Observer {
         updateChange();
     }
 
+    public static class PanelRelationship {
+        private ClassPanel parent;
+        private ClassPanel child;
+
+        public PanelRelationship(final ClassPanel parent, final ClassPanel child) {
+            this.parent = parent;
+            this.child = child;
+        }
+
+        public ClassPanel getParent() {
+            return this.parent;
+        }
+
+        public ClassPanel getChild() {
+            return this.child;
+        }
+
+    }
+
     public static class ClassPanel extends JPanel implements gCloneable<ClassPanel>, Cloneable {
         private final String name;
 
@@ -53,6 +74,8 @@ public class GUI extends JFrame implements j.Observer {
 
         //to help make dragging smooth
         public MouseEvent pressed;
+
+        ArrayList<PanelRelationship> relationships = new ArrayList<>();
 
         public ClassPanel(final String[][] details, final int x, final int y) {
             super(new GridLayout(0, 1));
@@ -112,7 +135,7 @@ public class GUI extends JFrame implements j.Observer {
             if (!isClass)
                 this.height += this.heightScale;
             this.setBounds(this.xDelta, this.yDelta, this.width, this.height);
-            this.setLocation(this.xDelta,this.yDelta);
+            this.setLocation(this.xDelta, this.yDelta);
             this.setBorder(BorderFactory.createLineBorder(Color.black));
             this.setVisible(true);
             //Add the mouse event handlers
@@ -205,7 +228,7 @@ public class GUI extends JFrame implements j.Observer {
         redrawGUI();
     }
 
-    private ClassPanel findClassPanel(final String name) {
+    private static ClassPanel findClassPanel(final String name) {
         for (ClassPanel p : GUI.classes) {
             if (p.name.equals(name))
                 return p;
@@ -213,7 +236,7 @@ public class GUI extends JFrame implements j.Observer {
         return null;
     }
 
-    private void GUIAddClass(final String name) {
+    private static void GUIAddClass(final String name) {
         ClassPanel newPanel = new ClassPanel(Controller.listAllClassDetails(name));
         GUI.classes.add(newPanel);
         guiWindow.getContentPane().add(newPanel);
@@ -221,7 +244,7 @@ public class GUI extends JFrame implements j.Observer {
         guiWindow.getContentPane().repaint();
     }
 
-    private void GUIRenameClass(final String name) {
+    private static void GUIRenameClass(final String name) {
         //The names are passed in the format [old name]\n[new name]
         String[] names = name.split("\n");
         if (names.length != 2)
@@ -229,7 +252,6 @@ public class GUI extends JFrame implements j.Observer {
 
         String oldName = names[0];
         String newName = names[1];
-        System.out.println(oldName + "\n" + newName);
         ClassPanel oldPanel = findClassPanel(oldName);
         if (oldPanel == null)
             return;
@@ -244,7 +266,7 @@ public class GUI extends JFrame implements j.Observer {
         guiWindow.getContentPane().repaint();
     }
 
-    private void GUIDeleteClass(final String name) {
+    private static void GUIDeleteClass(final String name) {
         ClassPanel panel = findClassPanel(name);
         GUI.classes.remove(panel);
         guiWindow.getContentPane().remove(panel);
@@ -252,7 +274,7 @@ public class GUI extends JFrame implements j.Observer {
         guiWindow.getContentPane().repaint();
     }
 
-    private void GUIUpdateAttribute(final String name) {
+    private static void GUIUpdateAttribute(final String name) {
         ClassPanel oldPanel = findClassPanel(name);
         if (oldPanel == null)
             return;
@@ -267,7 +289,7 @@ public class GUI extends JFrame implements j.Observer {
         guiWindow.getContentPane().repaint();
     }
 
-    private void GUIFullRefresh() {
+    private static void GUIFullRefresh() {
         guiWindow.getContentPane().removeAll();
         String[][][] classes = Controller.listEveryClassAndAllDetails();
         GUI.classes.clear();
@@ -299,6 +321,33 @@ public class GUI extends JFrame implements j.Observer {
         guiWindow.getContentPane().repaint();
     }
 
+    public static void GUIAddRelationship(final String classNames) {
+        /*
+        //The names are passed in the format [parent name]\n[child name]
+        String[] names = classNames.split("\n");
+        if (names.length != 2)
+            return;
+
+        String parentName = names[0];
+        String childName = names[1];
+        ClassPanel parentPanel = findClassPanel(parentName);
+        ClassPanel childPanel = findClassPanel(childName);
+        if (parentPanel == null || childPanel == null)
+            return;
+
+        PanelRelationship relationship = new PanelRelationship(parentPanel, childPanel);
+
+        parentPanel.relationships.add(relationship);
+        childPanel.relationships.add(relationship);
+        redrawGUI();
+        */
+    }
+
+    //Classes are passed in as "parent" + "\n" + "child"
+    public static void GUIDeleteRelationship(final String classes) {
+
+    }
+
     public void update(int reason, String msg) {
         switch (reason) {
             case Controller.ADD_CLASS:
@@ -310,9 +359,11 @@ public class GUI extends JFrame implements j.Observer {
                 updateChange();
                 break;
             case Controller.ADD_RELATIONSHIP:
+                GUIAddRelationship(msg);
                 updateChange();
                 break;
             case Controller.DELETE_RELATIONSHIP:
+                GUIDeleteRelationship(msg);
                 updateChange();
                 break;
             case Controller.DELETE_CLASS:

--- a/src/main/j/GUI.java
+++ b/src/main/j/GUI.java
@@ -108,6 +108,8 @@ public class GUI extends JFrame implements j.Observer {
 
             //Add the mouse event handlers
             ClassPanel thisPanel = this;
+
+            //We need a mouse listener to catch where the initial click is, otherwise the panel will "jump"
             this.addMouseListener(new MouseAdapter() {
                 @Override
                 public void mousePressed(MouseEvent me){
@@ -118,7 +120,10 @@ public class GUI extends JFrame implements j.Observer {
             this.addMouseMotionListener(new MouseMotionAdapter() {
                 @Override
                 public void mouseDragged(MouseEvent me) {
-                    me.translatePoint(thisPanel.getLocation().x - thisPanel.pressed.getX(), thisPanel.getLocation().y- thisPanel.pressed.getY());
+                    //Offset the translate by the difference between the panel's location and the initial click
+                    int xTranslated = thisPanel.getLocation().x - thisPanel.pressed.getX();
+                    int yTranslated = thisPanel.getLocation().y- thisPanel.pressed.getY();
+                    me.translatePoint(xTranslated, yTranslated);
                     thisPanel.setLocation(me.getX(),me.getY());
                 }
             });

--- a/src/main/j/GUI.java
+++ b/src/main/j/GUI.java
@@ -114,7 +114,7 @@ public class GUI extends JFrame implements j.Observer {
             this.setBounds(this.xDelta, this.yDelta, this.width, this.height);
             this.setLocation(this.xDelta,this.yDelta);
             this.setBorder(BorderFactory.createLineBorder(Color.black));
-
+            this.setVisible(true);
             //Add the mouse event handlers
             ClassPanel thisPanel = this;
             //We need a mouse listener to catch where the initial click is, otherwise the panel will "jump"
@@ -129,6 +129,7 @@ public class GUI extends JFrame implements j.Observer {
                     //We only need to update the coordinates when the user is done moving the boxes
                     thisPanel.xDelta = thisPanel.getLocation().x;
                     thisPanel.yDelta = thisPanel.getLocation().y;
+                    //updateChange();   //uncomment this if you want the undo/redo to undo the last box move
                 }
             });
 
@@ -283,8 +284,12 @@ public class GUI extends JFrame implements j.Observer {
 
     public static void redrawGUI() {
         guiWindow.getContentPane().removeAll();
+        guiWindow.getContentPane().revalidate();
+        guiWindow.getContentPane().repaint();
         for (ClassPanel c : GUI.classes)
-            drawClassPanel(c);
+            guiWindow.getContentPane().add(c);
+        guiWindow.getContentPane().revalidate();
+        guiWindow.getContentPane().repaint();
     }
 
     public static void drawClassPanel(final ClassPanel c) {
@@ -763,24 +768,7 @@ public class GUI extends JFrame implements j.Observer {
 
     }
 
-    public void handleDrag(final JPanel panel) {
-        final JPanel p = panel;
-        panel.addMouseMotionListener(new MouseMotionAdapter() {
-
-            @Override
-            public void mouseDragged(MouseEvent me) {
-                me.translatePoint(me.getComponent().getLocation().x, me.getComponent().getLocation().y);
-                p.setLocation(me.getX(), me.getY());
-            }
-
-        });
-
-    }
-
     public static void displayGUI() {
-        //SwingUtilities.updateComponentTreeUI(guiWindow);
-        //guiWindow.add(new ShapeDrawing());
-        //guiWindow.setVisible(true);
         guiWindow.getContentPane().removeAll();
         String[][][] classes = Controller.listEveryClassAndAllDetails();
         GUI.classes.clear();
@@ -794,7 +782,6 @@ public class GUI extends JFrame implements j.Observer {
 
         for (ClassPanel c : GUI.classes)
             drawClassPanel(c);
-
 
     }
 

--- a/src/main/j/GUI.java
+++ b/src/main/j/GUI.java
@@ -24,8 +24,13 @@ import static javax.swing.JOptionPane.YES_NO_OPTION;
 
 public class GUI extends JFrame implements j.Observer {
 
-    private static ArrayList<ClassPanel> classes = new ArrayList<>();
+    private static ArrayList<ClassPanel> classes;
     private final static Caretaker<ClassPanel> caretaker = new Caretaker<>();
+
+    static{
+        classes  = new ArrayList<>();
+        updateChange();
+    }
 
     public static class ClassPanel extends JPanel implements Cloneable {
         private final String name;
@@ -681,7 +686,7 @@ public class GUI extends JFrame implements j.Observer {
             }
         });
 
-
+/*
         Controller.addClass("test", 1);
         Controller.addField("test", "chicken", 1, "quack");
         Controller.addField("test", "chicken2", 1, "quack quack");
@@ -703,6 +708,8 @@ public class GUI extends JFrame implements j.Observer {
         GUI.classes.add(testClass);
         GUI.classes.add(testClass2);
 
+
+ */
 
         while (!Main.cview) {
             ;

--- a/src/main/j/GUI.java
+++ b/src/main/j/GUI.java
@@ -31,25 +31,6 @@ public class GUI extends JFrame implements j.Observer {
         updateChange();
     }
 
-    public static class PanelRelationship {
-        private ClassPanel parent;
-        private ClassPanel child;
-
-        public PanelRelationship(final ClassPanel parent, final ClassPanel child) {
-            this.parent = parent;
-            this.child = child;
-        }
-
-        public ClassPanel getParent() {
-            return this.parent;
-        }
-
-        public ClassPanel getChild() {
-            return this.child;
-        }
-
-    }
-
     public static class ClassPanel extends JPanel implements GCloneable<ClassPanel>, Cloneable {
         private final String name;
 
@@ -71,8 +52,6 @@ public class GUI extends JFrame implements j.Observer {
 
         //to help make dragging smooth
         public MouseEvent pressed;
-
-        ArrayList<PanelRelationship> relationships = new ArrayList<>();
 
         public ClassPanel(final String[][] details, final int x, final int y) {
             super(new GridLayout(0, 1));
@@ -319,30 +298,12 @@ public class GUI extends JFrame implements j.Observer {
     }
 
     public static void GUIAddRelationship(final String classNames) {
-        /*
         //The names are passed in the format [parent name]\n[child name]
-        String[] names = classNames.split("\n");
-        if (names.length != 2)
-            return;
-
-        String parentName = names[0];
-        String childName = names[1];
-        ClassPanel parentPanel = findClassPanel(parentName);
-        ClassPanel childPanel = findClassPanel(childName);
-        if (parentPanel == null || childPanel == null)
-            return;
-
-        PanelRelationship relationship = new PanelRelationship(parentPanel, childPanel);
-
-        parentPanel.relationships.add(relationship);
-        childPanel.relationships.add(relationship);
-        redrawGUI();
-        */
     }
 
     //Classes are passed in as "parent" + "\n" + "child"
     public static void GUIDeleteRelationship(final String classes) {
-
+        //The names are passed in the format [parent name]\n[child name]
     }
 
     //made these one liners to make it simpler to call undo/redo

--- a/src/main/j/GUI.java
+++ b/src/main/j/GUI.java
@@ -191,7 +191,7 @@ public class GUI extends JFrame implements j.Observer {
 
     public static GUI getInstance() {
         if (guiObserver == null)
-            return new GUI();
+            guiObserver = new GUI();
 
         return guiObserver;
     }
@@ -740,120 +740,11 @@ public class GUI extends JFrame implements j.Observer {
             }
         });
 
-/*
-        Controller.addClass("test", 1);
-        Controller.addField("test", "chicken", 1, "quack");
-        Controller.addField("test", "chicken2", 1, "quack quack");
-        LinkedList<String> ps = new LinkedList<>();
-        ps.add("p1");
-        ps.add("p2");
-        Controller.addMethod("test", "pizza", 1, "pizzaret", ps);
-
-        Controller.addClass("test2", 2);
-        Controller.addField("test2", "chicken", 1, "wee snaw");
-        LinkedList<String> ps2 = new LinkedList<>();
-        ps2.add("p1");
-        ps2.add("p2");
-        Controller.addMethod("test2", "pizza", 1, "pizzaret", ps2);
-        Controller.addMethod("test2", "pizza2", 1, "pizzaret", ps2);
-
-        ClassPanel testClass = new ClassPanel(Controller.listAllClassDetails("test"), 0, 0);
-        ClassPanel testClass2 = new ClassPanel(Controller.listAllClassDetails("test2"), 600, 300);
-        GUI.classes.add(testClass);
-        GUI.classes.add(testClass2);
-
-
- */
-
         while (!Main.cview) {
-            ;
+
         }
 
     }
-
-    public static void displayGUI() {
-        guiWindow.getContentPane().removeAll();
-        String[][][] classes = Controller.listEveryClassAndAllDetails();
-        GUI.classes.clear();
-
-        int x = 0;
-
-        for (String[][] c : classes) {
-            GUI.classes.add(new ClassPanel(c, x, 0));
-            x += 200;
-        }
-
-        for (ClassPanel c : GUI.classes)
-            drawClassPanel(c);
-
-    }
-
-//Start of absolute mess of code
-
-    public static class MyDraggableComponent
-            extends JComponent {
-
-        private volatile int screenX = 0;
-        private volatile int screenY = 0;
-        private volatile int myX = 0;
-        private volatile int myY = 0;
-
-
-        public MyDraggableComponent() {
-            super();
-            //this.setPreferredSize(new Dimension(100,300));
-            setBorder(new LineBorder(Color.BLUE, 3));
-            setBackground(Color.WHITE);
-            setBounds(0, 0, 100, 100);
-            setOpaque(false);
-
-            addMouseListener(new MouseListener() {
-
-                @Override
-                public void mouseClicked(MouseEvent e) {
-                }
-
-                @Override
-                public void mousePressed(MouseEvent e) {
-                    screenX = e.getXOnScreen();
-                    screenY = e.getYOnScreen();
-
-                    myX = getX();
-                    myY = getY();
-                }
-
-                @Override
-                public void mouseReleased(MouseEvent e) {
-                }
-
-                @Override
-                public void mouseEntered(MouseEvent e) {
-                }
-
-                @Override
-                public void mouseExited(MouseEvent e) {
-                }
-
-            });
-            addMouseMotionListener(new MouseMotionListener() {
-
-                @Override
-                public void mouseDragged(MouseEvent e) {
-                    int deltaX = e.getXOnScreen() - screenX;
-                    int deltaY = e.getYOnScreen() - screenY;
-
-                    setLocation(myX + deltaX, myY + deltaY);
-                }
-
-                @Override
-                public void mouseMoved(MouseEvent e) {
-                }
-
-            });
-        }
-
-    }
-
 
     public static class ShapeDrawing extends JComponent {
         //Start of blobs
@@ -913,9 +804,6 @@ public class GUI extends JFrame implements j.Observer {
             });
 
         }
-
-        //Made to pass up a graphic to the for loop I tried in displayGUI
-        //Graphics2D graphicy;
 
         public void paintComponent(Graphics g) {
             super.paintComponent(g);

--- a/src/main/j/Memento.java
+++ b/src/main/j/Memento.java
@@ -2,7 +2,7 @@ package j;
 
 import java.util.ArrayList;
 
-public class Memento<T extends gCloneable<T>> {
+public class Memento<T extends GCloneable<T>> {
     private final ArrayList<T> snap;
     private Memento(){
         this.snap = new ArrayList<>();
@@ -21,7 +21,7 @@ public class Memento<T extends gCloneable<T>> {
     }
 
 
-    public static <T extends gCloneable<T>> Memento<T> createSnapshot(final ArrayList<T> l){
+    public static <T extends GCloneable<T>> Memento<T> createSnapshot(final ArrayList<T> l){
         ArrayList<T> list = new ArrayList<>();
         for(T o : l){
             list.add(o.clone());
@@ -29,7 +29,7 @@ public class Memento<T extends gCloneable<T>> {
         return new Memento<>(list);
     }
 
-    public static <T extends gCloneable<T>> ArrayList<T> restoreSnapshot(final Memento<T> m){
+    public static <T extends GCloneable<T>> ArrayList<T> restoreSnapshot(final Memento<T> m){
         ArrayList<T> list = new ArrayList<>();
         for(T o : m.snap)
             list.add(o.clone());

--- a/src/main/j/Memento.java
+++ b/src/main/j/Memento.java
@@ -2,7 +2,7 @@ package j;
 
 import java.util.ArrayList;
 
-public class Memento<T> {
+public class Memento<T extends gCloneable<T>> {
     private final ArrayList<T> snap;
     private Memento(){
         this.snap = new ArrayList<>();
@@ -18,6 +18,22 @@ public class Memento<T> {
 
     public ArrayList<T> restore(){
         return this.snap;
+    }
+
+
+    public static <T extends gCloneable<T>> Memento<T> createSnapshot(final ArrayList<T> l){
+        ArrayList<T> list = new ArrayList<>();
+        for(T o : l){
+            list.add(o.clone());
+        }
+        return new Memento<>(list);
+    }
+
+    public static <T extends gCloneable<T>> ArrayList<T> restoreSnapshot(final Memento<T> m){
+        ArrayList<T> list = new ArrayList<>();
+        for(T o : m.snap)
+            list.add(o.clone());
+        return list;
     }
 
 }

--- a/src/main/j/Memento.java
+++ b/src/main/j/Memento.java
@@ -1,0 +1,23 @@
+package j;
+
+import java.util.ArrayList;
+
+public class Memento<T> {
+    private final ArrayList<T> snap;
+    private Memento(){
+        this.snap = new ArrayList<>();
+    }
+
+    public Memento(final ArrayList<T> snap) {
+        this.snap = snap;
+    }
+
+    public void add(final T obj){
+        this.snap.add(obj);
+    }
+
+    public ArrayList<T> restore(){
+        return this.snap;
+    }
+
+}

--- a/src/main/j/ModelDiagram.java
+++ b/src/main/j/ModelDiagram.java
@@ -6,7 +6,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.Scanner;

--- a/src/main/j/ModelDiagram.java
+++ b/src/main/j/ModelDiagram.java
@@ -52,8 +52,7 @@ public class ModelDiagram {
      */
     public static Controller.STATUS_CODES redo() {
         try {
-            ArrayList<ClassBox> snapList = caretaker.redo().restore();
-            restoreSnapshot(snapList);
+            createdClasses = Memento.restoreSnapshot(caretaker.redo());
         } catch (Exception ignored) {
             return Controller.STATUS_CODES.REDO_FAILED;
         }
@@ -70,8 +69,7 @@ public class ModelDiagram {
      */
     public static Controller.STATUS_CODES undo() {
         try {
-            ArrayList<ClassBox> snapList = caretaker.undo().restore();
-            restoreSnapshot(snapList);
+            createdClasses = Memento.restoreSnapshot(caretaker.undo());
         } catch (Exception ignored) {
             return Controller.STATUS_CODES.UNDO_FAILED;
         }
@@ -79,29 +77,6 @@ public class ModelDiagram {
         return Controller.STATUS_CODES.SUCCESS;
     }
 
-    /**
-     * Creates a Memento Object using the createdClasses list
-     *
-     * @param snapshot the createdClasses list (this should always be ModelDiagram.createdClasses)
-     */
-    private static ArrayList<ClassBox> createSnapshot(final ArrayList<ClassBox> snapshot) {
-        ArrayList<ClassBox> snap = new ArrayList<>();
-        for (ClassBox classBox : snapshot) {
-            snap.add(classBox.clone());
-        }
-        return snap;
-    }
-
-    /**
-     * Creates a new list using a Memento object's object, then it to ModelDiagram.createdClasses
-     */
-    public static void restoreSnapshot(final ArrayList<ClassBox> snapshot) {
-        ArrayList<ClassBox> list = new ArrayList<>();
-        for (ClassBox cb : snapshot) {
-            list.add(cb.clone());
-        }
-        createdClasses = list;
-    }
 
     /**
      * Searches the list of created classes for a ClassBox with the given name

--- a/src/main/j/ModelDiagram.java
+++ b/src/main/j/ModelDiagram.java
@@ -36,7 +36,7 @@ public class ModelDiagram {
      */
     public static Controller.STATUS_CODES updateChange(final int reason, final String msg) {
         try {
-            caretaker.updateChange(Memento.createSnapshot(createdClasses));
+            caretaker.addChange(Memento.createSnapshot(createdClasses));
         } catch (Exception ignored) {
             return Controller.STATUS_CODES.EXCEPTION;
         }

--- a/src/main/j/ModelDiagram.java
+++ b/src/main/j/ModelDiagram.java
@@ -36,9 +36,7 @@ public class ModelDiagram {
      */
     public static Controller.STATUS_CODES updateChange(final int reason, final String msg) {
         try {
-            ArrayList<ClassBox> snapList = createSnapshot(createdClasses);
-            j.Memento<ClassBox> snapshot = new j.Memento<>(snapList);
-            caretaker.updateChange(snapshot);
+            caretaker.updateChange(Memento.createSnapshot(createdClasses));
         } catch (Exception ignored) {
             return Controller.STATUS_CODES.EXCEPTION;
         }

--- a/src/main/j/Observable.java
+++ b/src/main/j/Observable.java
@@ -2,6 +2,6 @@ package j;
 
 public interface Observable {
 
-    void notifyObservers();
+    void notifyObservers(int reason, String msg);
 
 }

--- a/src/main/j/Observer.java
+++ b/src/main/j/Observer.java
@@ -2,6 +2,6 @@ package j;
 
 public interface Observer {
 
-    void update();
+    void update(int reason, String msg);
 
 }

--- a/src/main/j/gCloneable.java
+++ b/src/main/j/gCloneable.java
@@ -1,0 +1,5 @@
+package j;
+
+public interface gCloneable<T> {
+    T clone();
+}

--- a/src/main/j/gCloneable.java
+++ b/src/main/j/gCloneable.java
@@ -1,5 +1,0 @@
-package j;
-
-public interface gCloneable<T> {
-    T clone();
-}


### PR DESCRIPTION
- Gui now has movable moves, everything works except for drawing lines for relationships
- Undo/redo now has menu options and pressing 'u' undos while pressing 'r' redos
- redid memento and caretaker to be generic (to be able to use them with GUI)
    - caretaker is no longer a singleton
- made the GUI observer the singleton
- added a "GCloneable" (GourmetJava Cloneable) interface for Prototype because I needed the clone() method in a generic (Cloneable's clone() is not easy to get to in generics)
- I got rid of a lot of commented out code